### PR TITLE
fix: 修复浏览器启动后立刻退出无法使用的问题

### DIFF
--- a/aunly_bbot/function/event/bot_launch.py
+++ b/aunly_bbot/function/event/bot_launch.py
@@ -43,11 +43,10 @@ async def main(app: Ariadne):
                 ]
             )
 
-        page = browser_context.context.pages[0]
-        version = await page.evaluate("navigator.appVersion")
-        logger.info(f"[BiliBili推送] 浏览器启动完成，当前版本 {version}")
-        logger.debug(await browser_context.context.cookies())
-        await page.close()
+        async with browser_context.page() as page:
+            version = await page.evaluate("navigator.appVersion")
+            logger.info(f"[BiliBili推送] 浏览器启动完成，当前版本 {version}")
+            logger.debug(await browser_context.context.cookies())
     except Exception as e:
         capture_exception(e)
         logger.error(f"[BiliBili推送] 浏览器启动失败 {e}")


### PR DESCRIPTION
该问题会导致调用浏览器新建页面等操作时报 `playwright._impl._api_types.Error: Target page, context or browser has been closed` 的错误